### PR TITLE
fix: copy page and view as markdown in docs

### DIFF
--- a/app/(app)/docs/[[...slug]]/page.tsx
+++ b/app/(app)/docs/[[...slug]]/page.tsx
@@ -96,8 +96,10 @@ export default async function Page(props: {
                                 </h1>
                                 <div className="docs-nav bg-background/80 border-border/50 fixed inset-x-0 bottom-0 isolate z-1001 flex items-center gap-2 border-t px-6 py-4 backdrop-blur-sm sm:static sm:z-0 sm:border-t-0 sm:bg-transparent sm:px-0 sm:pt-1.5 sm:backdrop-blur-none">
                                     <DocsCopyPage
-                                        // @ts-expect-error - revisit fumadocs types.
-                                        page={doc.content}
+                                        // @ts-expect-error - getText exists on DocMethods but not on loader's PageData type
+                                        page={await page.data.getText(
+                                            "raw"
+                                        )}
                                         url={absoluteUrl(page.url)}
                                     />
                                     {neighbours.previous && (

--- a/components/docs-copy-page.tsx
+++ b/components/docs-copy-page.tsx
@@ -25,9 +25,19 @@ Help me understand how to use it. Be ready to explain concepts, give examples, o
     )}`
 }
 
+function openAsMarkdown(content: string) {
+    const blob = new Blob([content], { type: "text/markdown" })
+    window.open(URL.createObjectURL(blob), "_blank")
+}
+
 const menuItems = {
-    markdown: (url: string) => (
-        <a href={`${url}.md`} target="_blank" rel="noopener noreferrer">
+    markdown: (_url: string, onOpen?: () => void) => (
+        <a
+            href="#"
+            onClick={(e) => {
+                e.preventDefault()
+                onOpen?.()
+            }}>
             <svg strokeLinejoin="round" viewBox="0 0 22 16">
                 <path
                     fillRule="evenodd"
@@ -125,7 +135,12 @@ export function DocsCopyPage({ page, url }: { page: string; url: string }) {
                     <DropdownMenuContent align="end" className="shadow-none">
                         {Object.entries(menuItems).map(([key, value]) => (
                             <DropdownMenuItem key={key} asChild>
-                                {value(url)}
+                                {value(
+                                    url,
+                                    key === "markdown"
+                                        ? () => openAsMarkdown(page)
+                                        : undefined
+                                )}
                             </DropdownMenuItem>
                         ))}
                     </DropdownMenuContent>
@@ -141,7 +156,12 @@ export function DocsCopyPage({ page, url }: { page: string; url: string }) {
                             asChild
                             key={key}
                             className="*:[svg]:text-muted-foreground w-full justify-start text-base font-normal">
-                            {value(url)}
+                            {value(
+                                url,
+                                key === "markdown"
+                                    ? () => openAsMarkdown(page)
+                                    : undefined
+                            )}
                         </Button>
                     ))}
                 </PopoverContent>


### PR DESCRIPTION
## Summary
- Use fumadocs `getText('raw')` to get actual markdown content instead of undefined `doc.content`, fixing the "Copy Page" button
- Change "View as Markdown" to open content via blob URL instead of linking to a non-existent `.md` route

## Test plan
- [x] Click "Copy Page" on a docs page and verify markdown is copied to clipboard
- [x] Click "View as Markdown" from the dropdown and verify it opens raw markdown in a new tab
- [x] Verify the mobile popover version also works